### PR TITLE
Add text templating support and changed file information paste to body text

### DIFF
--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Určuje jazyk textového bloku Talk v událostech."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Šablona čistého textu"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Umožňuje vytvořit vlastní textovou šablonu. Zástupné symboly jsou: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Výchozí (UI)"
   },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -401,7 +401,13 @@
   "options_event_description_lang_hint": {
     "message": "Steuert die Sprache des Talk-Textblocks in Terminen."
   },
-  "options_lang_default": {
+  "options_sharing_plaintext_template_label": {
+    "message": "Text-Vorlage"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Ermöglicht es dir, deine eigene Textvorlage zu erstellen. Die Platzhalter sind: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
+  "options_tab_signature": {
     "message": "Standard (UI)"
   },
   "options_about_version_label": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -407,7 +407,7 @@
   "options_sharing_plaintext_template_hint": {
     "message": "Ermöglicht es dir, deine eigene Textvorlage zu erstellen. Die Platzhalter sind: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
   },
-  "options_tab_signature": {
+  "options_lang_default": {
     "message": "Standard (UI)"
   },
   "options_about_version_label": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -407,7 +407,7 @@
   "options_sharing_plaintext_template_hint": {
     "message": "Let's you create your custom text template. The placeholders are: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
   },
-  "options_tab_signature": {
+  "options_lang_default": {
     "message": "Default (UI)"
   },
   "options_about_version_label": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -401,7 +401,13 @@
   "options_event_description_lang_hint": {
     "message": "Controls the language of the Talk text block in events."
   },
-  "options_lang_default": {
+  "options_sharing_plaintext_template_label": {
+    "message": "Plaintext template"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Let's you create your custom text template. The placeholders are: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
+  "options_tab_signature": {
     "message": "Default (UI)"
   },
   "options_about_version_label": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Controla el idioma del bloque de texto de Talk en eventos."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Plantilla de texto plano"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Permite crear tu propia plantilla de texto personalizada. Los marcadores son: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Predeterminado (IU)"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Contrôle la langue du bloc de texte Talk dans les événements."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Modèle en texte brut"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Permet de créer votre propre modèle de texte personnalisé. Les variables sont : {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Par défaut (UI)"
   },

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Az eseményekben megjelenő Talk szövegblokk nyelvét állítja be."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Egyszerű szöveges sablon"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Lehetővé teszi saját egyéni szövegsablon létrehozását. A helykitöltők: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Alapértelmezett (UI)"
   },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Controlla la lingua del blocco di testo Talk negli eventi."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Modello di testo semplice"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Consente di creare il proprio modello di testo personalizzato. I segnaposto sono: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Predefinito (UI)"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "イベント内の Talk テキストブロックの言語を設定します。"
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "プレーンテキストテンプレート"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "独自のカスタムテキストテンプレートを作成できます。プレースホルダーは次のとおりです: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "既定（UI）"
   },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Bepaalt de taal van het Talk-tekstblok in afspraken."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Plattekstsjabloon"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Hiermee kunt u uw eigen aangepaste tekstsjabloon maken. De tijdelijke aanduidingen zijn: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Standaard (UI)"
   },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Kontroluje język bloku tekstowego Talk w wydarzeniach."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Szablon tekstu jawnego"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Pozwala na stworzenie własnego szablonu tekstowego. Symbole zastępcze to: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Domyślny (UI)"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Controla o idioma do bloco de texto do Talk em eventos."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Modelo de texto simples"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Permite criar seu próprio modelo de texto personalizado. Os espaços reservados são: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Padrão (UI)"
   },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Controla o idioma do bloco de texto do Talk em eventos."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Modelo de texto simples"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Permite criar o seu próprio modelo de texto personalizado. Os espaços reservados são: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "Predefinido (UI)"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "Определяет язык текстового блока Talk в событиях."
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "Шаблон простого текста"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "Позволяет создать собственный текстовый шаблон. Плейсхолдеры: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "По умолчанию (UI)"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "控制事件中 Talk 文本块的语言。"
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "纯文本模板"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "允许您创建自定义文本模板。占位符为：{URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "默认（UI）"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -401,6 +401,12 @@
   "options_event_description_lang_hint": {
     "message": "控制事件中 Talk 文字區塊的語言。"
   },
+  "options_sharing_plaintext_template_label": {
+    "message": "純文字範本"
+  },
+  "options_sharing_plaintext_template_hint": {
+    "message": "允許您建立自訂文字範本。預留位置為：{URL}, {PASSWORD}, {預留位置}, {RIGHTS}, {NOTE}"
+  },
   "options_lang_default": {
     "message": "預設（UI）"
   },

--- a/modules/htmlSanitizer.js
+++ b/modules/htmlSanitizer.js
@@ -346,7 +346,7 @@
   }
 
   /**
-   * Convert plain text paragraphs into lightweight HTML.
+   * Convert plain text into lightweight HTML with line breaks.
    * @param {string} value
    * @returns {string}
    */
@@ -355,11 +355,7 @@
     if (!normalized){
       return "";
     }
-    const paragraphs = normalized.split(/\n{2,}/).map((part) => part.trim()).filter(Boolean);
-    return paragraphs.map((part) => {
-      const escaped = escapeHtml(part).replace(/\n/g, "<br>");
-      return `<p>${escaped}</p>`;
-    }).join("\n");
+    return escapeHtml(normalized).replace(/\n/g, "<br />");
   }
 
   /**

--- a/modules/ncSharing.js
+++ b/modules/ncSharing.js
@@ -1311,6 +1311,29 @@
       passwordText = String(result.password || "").trim();
     }
 
+    if (!customTemplate){
+      const userTemplateKey = NCSharingStorage?.SHARING_KEYS?.plaintextTemplate;
+      const stored = userTemplateKey ? await browser.storage.local.get([userTemplateKey]) : {};
+      const userTemplate = userTemplateKey ? String(stored[userTemplateKey] || "").trim() : "";
+      if (userTemplate){
+        const replacements = {
+          URL: downloadUrl || "",
+          PASSWORD: passwordText,
+          EXPIRATIONDATE: String(result.expireDate || ""),
+          RIGHTS: permissionsPlain,
+          NOTE: noteText
+        };
+        let rendered = userTemplate;
+        Object.keys(replacements).forEach((key) => {
+          rendered = rendered.split(`{${key}}`).join(replacements[key]);
+        });
+        const plainText = normalizePlainTextBlock(rendered);
+        if (plainText){
+          return plainText;
+        }
+      }
+    }
+
     if (customTemplate){
       const emptyPlaceholders = [];
       if (!downloadUrl){

--- a/modules/sharingStorage.js
+++ b/modules/sharingStorage.js
@@ -21,7 +21,8 @@ const NCSharingStorage = (() => {
     defaultExpireDays: "sharingDefaultExpireDays",
     attachmentsAlwaysConnector: "sharingAttachmentsAlwaysConnector",
     attachmentsOfferAboveEnabled: "sharingAttachmentsOfferAboveEnabled",
-    attachmentsOfferAboveMb: "sharingAttachmentsOfferAboveMb"
+    attachmentsOfferAboveMb: "sharingAttachmentsOfferAboveMb",
+    plaintextTemplate: "sharingPlaintextTemplate"
   };
   const LEGACY_KEYS = {
     basePath: "fileLinkBasePath",

--- a/options.html
+++ b/options.html
@@ -73,9 +73,7 @@ body{
   margin:0;
 }
 .field-stack{display:flex; flex-direction:column; gap:6px; max-width:420px; width:100%;}
-input[type="url"], input[type="text"], input[type="password"], input[type="number"], select{
-  height:var(--control-height);
-  padding:0 var(--control-padding-x);
+input[type="url"], input[type="text"], input[type="password"], input[type="number"], select, textarea{
   border:1px solid var(--tb-border-strong);
   border-radius:var(--control-radius);
   width:100%;
@@ -83,6 +81,15 @@ input[type="url"], input[type="text"], input[type="password"], input[type="numbe
   background:var(--tb-surface);
   color:var(--tb-text);
   font:inherit;
+}
+input[type="url"], input[type="text"], input[type="password"], input[type="number"], select{
+  height:var(--control-height);
+  padding:0 var(--control-padding-x);
+}
+textarea{
+  padding:8px;
+  resize:vertical;
+  font-family:monospace;
 }
 input[type="checkbox"],
 input[type="radio"]{
@@ -698,6 +705,13 @@ footer{
         <div>
           <select id="eventDescriptionLang"></select>
           <p class="hint" data-i18n="options_event_description_lang_hint">Controls the language of the Talk text block in events.</p>
+        </div>
+      </div>
+      <div class="row" id="sharingPlaintextTemplateRow">
+        <label for="sharingPlaintextTemplate" data-i18n="options_sharing_plaintext_template_label">Plaintext template</label>
+        <div>
+          <textarea id="sharingPlaintextTemplate" rows="10"></textarea>
+          <p class="hint" data-i18n="options_sharing_plaintext_template_hint">Placeholders: {URL}, {PASSWORD}, {EXPIRATIONDATE}, {RIGHTS}, {NOTE}</p>
         </div>
       </div>
     </fieldset>

--- a/options.js
+++ b/options.js
@@ -101,6 +101,7 @@ const shareBlockLangRow = document.getElementById("shareBlockLangRow");
 const shareBlockLangSelect = document.getElementById("shareBlockLang");
 const eventDescriptionLangRow = document.getElementById("eventDescriptionLangRow");
 const eventDescriptionLangSelect = document.getElementById("eventDescriptionLang");
+const sharingPlaintextTemplateInput = document.getElementById("sharingPlaintextTemplate");
 const emailSignaturePolicyHint = document.getElementById("emailSignaturePolicyHint");
 const emailSignatureOnComposeRow = document.getElementById("emailSignatureOnComposeRow");
 const emailSignatureOnComposeInput = document.getElementById("emailSignatureOnCompose");
@@ -1017,6 +1018,7 @@ async function load(){
     "talkDefaultRoomType",
     "shareBlockLang",
     "eventDescriptionLang",
+    SHARING_KEYS.plaintextTemplate,
     EMAIL_SIGNATURE_KEYS.onCompose,
     EMAIL_SIGNATURE_KEYS.onReply,
     EMAIL_SIGNATURE_KEYS.onForward
@@ -1138,6 +1140,11 @@ async function load(){
   }
   if (eventDescriptionLangSelect){
     eventDescriptionLangSelect.value = normalizeLangChoice(storedEventDescriptionLang);
+  }
+  if (sharingPlaintextTemplateInput){
+    sharingPlaintextTemplateInput.value = stored[SHARING_KEYS.plaintextTemplate] !== undefined
+      ? stored[SHARING_KEYS.plaintextTemplate]
+      : "";
   }
   applyPolicySettingsOverlay();
   await refreshTalkSystemAddressbookState({ forceRefresh: true });
@@ -1351,6 +1358,7 @@ async function save(){
   let talkDefaultRoomType = getSelectedTalkDefaultRoomType();
   let shareBlockLang = normalizeLangChoice(shareBlockLangSelect?.value);
   let eventDescriptionLang = normalizeLangChoice(eventDescriptionLangSelect?.value);
+  let sharingPlaintextTemplate = sharingPlaintextTemplateInput ? sharingPlaintextTemplateInput.value : "";
   let emailSignatureOnCompose = emailSignatureOnComposeInput ? !!emailSignatureOnComposeInput.checked : false;
   let emailSignatureOnReply = emailSignatureOnReplyInput ? !!emailSignatureOnReplyInput.checked : false;
   let emailSignatureOnForward = emailSignatureOnForwardInput ? !!emailSignatureOnForwardInput.checked : false;
@@ -1460,6 +1468,7 @@ async function save(){
     talkDefaultRoomType,
     shareBlockLang,
     eventDescriptionLang,
+    [SHARING_KEYS.plaintextTemplate]: sharingPlaintextTemplate,
     [EMAIL_SIGNATURE_KEYS.onCompose]: emailSignatureOnCompose,
     [EMAIL_SIGNATURE_KEYS.onReply]: emailSignatureOnReply,
     [EMAIL_SIGNATURE_KEYS.onForward]: emailSignatureOnForward

--- a/tools/share-plaintext-contract-check.js
+++ b/tools/share-plaintext-contract-check.js
@@ -247,6 +247,7 @@ function createHarness(){
   context.globalThis = context;
   vm.createContext(context);
   loadScriptIntoContext("modules/shareTemplateContract.js", context);
+  loadScriptIntoContext("modules/sharingStorage.js", context);
   loadScriptIntoContext("modules/ncSharing.js", context);
   loadScriptIntoContext("modules/bgComposeShareInsert.js", context);
   return { context, storageState, composeState };
@@ -360,11 +361,49 @@ async function testInsertRejectsMissingPlainTextVariant(){
   assert(result.error === "tab/html/plainText missing", "Insert handler should report the explicit missing-variant rule");
 }
 
+async function testPlainTextInsertUsesCustomTemplate(){
+  const { context, storageState, composeState } = createHarness();
+  const customTemplate = "LINK: {URL}\nPASS: {PASSWORD}\nNOTE: {NOTE}";
+  storageState.sharingPlaintextTemplate = customTemplate;
+  composeState.detailsByTab.set(10, {
+    isPlainText: true,
+    deliveryFormat: "plaintext",
+    body: "",
+    plainTextBody: "Existing body"
+  });
+
+  const result = await context.NCSharing.buildPlainTextBlock({
+    shareUrl: "https://cloud.example/s/abc123",
+    password: "SecretPassword",
+    expireDate: "2026-12-31",
+    permissions: { read: true, create: false, write: false, delete: false }
+  }, {
+    noteEnabled: true,
+    note: "My custom note",
+    permissions: { read: true, create: false, write: false, delete: false }
+  });
+
+  assert(result.includes("LINK: https://cloud.example/s/abc123"), "Custom template must resolve {URL}");
+  assert(result.includes("PASS: SecretPassword"), "Custom template must resolve {PASSWORD}");
+  assert(result.includes("NOTE: My custom note"), "Custom template must resolve {NOTE}");
+
+  const insertResult = await context.handleSharingInsertHtmlMessage({
+    tabId: 10,
+    html: "<p>ignored</p>",
+    plainText: result
+  });
+
+  assert(insertResult.ok === true, "Insert with custom template should succeed");
+  const writtenBody = composeState.setCalls[0].details.plainTextBody;
+  assert(writtenBody.includes("LINK: https://cloud.example/s/abc123"), "Final body must contain rendered template");
+}
+
 async function run(){
   await testLocalPlainTextBuildSkipsSanitizer();
   await testCustomTemplatePrunesEmptyPasswordAndSanitizes();
   await testCustomTemplateUsesSeparatePasswordHint();
   await testPlainTextInsertCompactsMarkedRightsSegment();
+  await testPlainTextInsertUsesCustomTemplate();
   await testInsertRejectsMissingPlainTextVariant();
   console.log("[OK] share-plaintext-contract-check passed");
 }


### PR DESCRIPTION
Explanation from commits:

I added a templating option in the settings.
This allows users to define a custom **text** template (I have not
tested if this works with written html in the template).    
If empty, the default template is used.

I have also changed plainTextToHtml so that the template get's
pasted as body text and not a paragraph which is imo the better default
for text only emails.

---

I can also change stuff if there's something you don't like or if it should have
better html support.