### PR TITLE
Focus fix talk popup

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,6 +28,7 @@ It complements:
   - [6.3 Migration notes](#63-migration-notes)
 - [7. Calendar integration (Talk button in event editor)](#7-calendar-integration-talk-button-in-event-editor)
   - [7.1 Why a custom toolbar experiment exists](#71-why-a-custom-toolbar-experiment-exists)
+  - [7.1.1 Why the Talk popup is assigned with `setPopup()`](#711-why-the-talk-popup-is-assigned-with-setpopup)
   - [7.2 Editor variants: dialog vs tab](#72-editor-variants-dialog-vs-tab)
   - [7.2.1 Why manual tab/window correlation exists today](#721-why-manual-tabwindow-correlation-exists-today)
   - [7.3 `ncCalToolbar` API surface (editor-targeted)](#73-nccaltoolbar-api-surface-editor-targeted)
@@ -341,6 +342,21 @@ Current implementation:
   - tracked close lifecycle (`onTrackedEditorClosed`)
 - `experiments/calendar/**` remains untouched and is used only for persisted item monitoring.
 - Business logic remains in background runtime modules (`modules/bgState.js`, `modules/bgComposeAttachments.js`, `modules/bgComposeShareCleanup.js`, `modules/bgComposeShareInsert.js`, `modules/bgComposePasswordDispatch.js`, `modules/passwordPolicyRuntime.js`, `modules/bgCompose.js`, `modules/bgCalendarLifecycle.js`, `modules/bgCalendar.js`, `modules/bgRouter.js`, `modules/talkAddressbook.js`, `modules/talkcore.js`).
+
+### 7.1.1 Why the Talk popup is assigned with `setPopup()`
+
+The Talk wizard uses the native `calendar_item_action` popup so Thunderbird owns the foreground popup behavior in event editors.
+
+The popup is assigned at runtime with `browser.calendarItemAction.setPopup({ popup: "ui/talkDialog.html" })` instead of `calendar_item_action.default_popup` in `manifest.json`.
+
+Reason:
+- The bundled upstream calendar experiment processes manifest popup paths itself.
+- In packaged Thunderbird builds, the manifest value can already be expanded to a `moz-extension://...` URL before that code runs.
+- Resolving that value again can produce a broken nested URL like `moz-extension://.../moz-extension://.../ui/talkDialog.html`.
+
+This is a compatibility workaround, not the preferred long-term shape. If upstream fixes the popup path handling so already expanded URLs are not resolved again, move the Talk popup back to `calendar_item_action.default_popup` in `manifest.json` and remove the runtime `setPopup()` setup.
+
+The Talk context is prepared by `ncCalToolbar.onClicked` and claimed by the popup through `talk:claimPopupContext`.
 
 ### 7.2 Editor variants: dialog vs tab
 

--- a/modules/bgCalendar.js
+++ b/modules/bgCalendar.js
@@ -10,6 +10,27 @@
  * calendar item monitoring/synchronization.
  */
 
+const TALK_DIALOG_POPUP_PATH = "ui/talkDialog.html";
+
+void configureTalkCalendarItemPopup();
+
+async function configureTalkCalendarItemPopup(){
+  try{
+    if (typeof browser.calendarItemAction?.setPopup !== "function"){
+      console.error("[NCBG] calendarItemAction.setPopup missing");
+      return;
+    }
+    // Runtime popup assignment avoids the current upstream experiment bug where
+    // manifest default_popup can be resolved twice into a broken nested
+    // moz-extension://.../moz-extension://... URL. Move this back to the
+    // manifest once upstream handles already expanded popup URLs correctly.
+    await browser.calendarItemAction.setPopup({ popup: TALK_DIALOG_POPUP_PATH });
+    L("calendar item action popup configured", { popup: TALK_DIALOG_POPUP_PATH });
+  }catch(error){
+    console.error("[NCBG] calendar item action popup configure failed", error);
+  }
+}
+
 /**
  * Entry point from the official calendar_item_action button.
  * Click context/snapshot is provided by the ncCalToolbar bridge API.
@@ -37,76 +58,79 @@ browser.ncCalToolbar?.onClicked?.addListener((snapshot) => {
           console.error("[NCBG] system addressbook check on talk click failed", error);
         });
 
-      const getCurrentApi = browser.ncCalToolbar?.getCurrent;
-      if (typeof getCurrentApi !== "function"){
-        console.error("[NCBG] ncCalToolbar.getCurrent missing");
-        return;
-      }
-      const snapshotOptions = { returnFormat: "ical" };
-      snapshotOptions.editorId = requestedEditorId;
-      const currentSnapshot = await getCurrentApi(snapshotOptions);
-      const resolvedEditorId = requestedEditorId;
-      L("ncCalToolbar.onClicked", {
-        hasEditorId: !!resolvedEditorId,
-        hasIcal:
-          currentSnapshot?.format === "ical" &&
-          typeof currentSnapshot?.item === "string" &&
-          !!currentSnapshot.item
-      });
-      if (
-        !currentSnapshot ||
-        currentSnapshot.format !== "ical" ||
-        typeof currentSnapshot.item !== "string" ||
-        !currentSnapshot.item
-      ){
-        console.error("[NCBG] ncCalToolbar.onClicked missing snapshot");
-        return;
-      }
-
       const contextId = createCalendarWizardContextId();
       const context = setCalendarWizardContext(contextId, {
         source: "ncCalToolbar",
-        editorId: resolvedEditorId,
+        editorId: requestedEditorId,
         item: {
-          id: currentSnapshot.id || "",
-          calendarId: currentSnapshot.calendarId || "",
-          type: currentSnapshot.type || "event",
-          format: "ical",
-          item: currentSnapshot.item
+          id: "",
+          calendarId: "",
+          type: "event"
         },
         event: {},
         metadata: {}
       });
+      mergeCalendarSnapshotIntoWizardContext(context, snapshot);
       refreshCalendarWizardContextSnapshot(context);
-
-      const url = new URL(browser.runtime.getURL("ui/talkDialog.html"));
-      url.searchParams.set("contextId", contextId);
-      L("talk wizard open", {
+      setLatestCalendarWizardPopupContext(contextId);
+      L("ncCalToolbar.onClicked", {
+        hasEditorId: true,
+        hasIcal:
+          context.item?.format === "ical" &&
+          typeof context.item?.item === "string" &&
+          !!context.item.item,
+        snapshotSource: context.snapshotSource || "",
+        hasLiveStart: typeof context.event?.startTimestamp === "number"
+      });
+      L("talk wizard popup context prepared", {
         source: "ncCalToolbar",
         contextId,
         editorId: context.editorId || "",
         calendarId: context.item?.calendarId || "",
         itemId: context.item?.id || ""
       });
-      const popupWindow = await browser.windows.create({
-        type: "popup",
-        url: url.toString(),
-        width: TALK_POPUP_WIDTH,
-        height: TALK_POPUP_HEIGHT
-      });
-      const focusApplied = await focusPopupWindowBestEffort(popupWindow, {
-        label: "talk wizard popup"
-      });
-      L("talk wizard popup focus", {
-        contextId,
-        windowId: Number(popupWindow?.id) || 0,
-        focusApplied
-      });
+      void hydrateTalkWizardContextFromEditor(requestedEditorId, contextId);
     }catch(error){
       console.error("[NCBG] ncCalToolbar.onClicked error", error);
     }
   })();
 });
+
+async function hydrateTalkWizardContextFromEditor(editorId, contextId){
+  try{
+    const getCurrentApi = browser.ncCalToolbar?.getCurrent;
+    if (typeof getCurrentApi !== "function"){
+      console.error("[NCBG] ncCalToolbar.getCurrent missing");
+      return;
+    }
+    const context = getCalendarWizardContext(contextId);
+    if (!context){
+      return;
+    }
+    const currentSnapshot = await getCurrentApi({
+      returnFormat: "ical",
+      editorId
+    });
+    if (!currentSnapshot){
+      console.error("[NCBG] ncCalToolbar.onClicked missing snapshot");
+      return;
+    }
+    mergeCalendarSnapshotIntoWizardContext(context, currentSnapshot);
+    refreshCalendarWizardContextSnapshot(context);
+    L("ncCalToolbar.onClicked snapshot hydrated", {
+      contextId,
+      hasIcal:
+        context.item?.format === "ical" &&
+        typeof context.item?.item === "string" &&
+        !!context.item.item,
+      snapshotSource: context.snapshotSource || "",
+      calendarId: context.item?.calendarId || "",
+      itemId: context.item?.id || ""
+    });
+  }catch(error){
+    console.error("[NCBG] ncCalToolbar snapshot hydration failed", error);
+  }
+}
 
 /**
  * Lifecycle callback for tracked editor close events from ncCalToolbar.

--- a/modules/bgCalendarLifecycle.js
+++ b/modules/bgCalendarLifecycle.js
@@ -136,6 +136,8 @@ function createCalendarWizardContextId(){
   return `${Date.now()}-${rand}`;
 }
 
+let latestCalendarWizardPopupContextId = "";
+
 function setCalendarWizardContext(contextId, entry){
   pruneCalendarWizardContexts();
   const next = Object.assign({}, entry || {}, { created: Date.now() });
@@ -149,8 +151,21 @@ function getCalendarWizardContext(contextId){
   return CALENDAR_WIZARD_CONTEXTS.get(contextId) || null;
 }
 
+function setLatestCalendarWizardPopupContext(contextId){
+  latestCalendarWizardPopupContextId = getCalendarWizardContext(contextId) ? contextId : "";
+}
+
+function consumeLatestCalendarWizardPopupContext(){
+  const contextId = latestCalendarWizardPopupContextId;
+  latestCalendarWizardPopupContextId = "";
+  return getCalendarWizardContext(contextId) ? contextId : "";
+}
+
 function deleteCalendarWizardContext(contextId){
   if (!contextId) return;
+  if (latestCalendarWizardPopupContextId === contextId){
+    latestCalendarWizardPopupContextId = "";
+  }
   CALENDAR_WIZARD_CONTEXTS.delete(contextId);
 }
 

--- a/modules/bgRouter.js
+++ b/modules/bgRouter.js
@@ -84,6 +84,14 @@ browser.runtime.onMessage.addListener((msg, sender) => {
       return messageError("talk:getSystemAddressbookStatus", error);
     }
   }
+  if (msg.type === "talk:claimPopupContext"){
+    const contextId = consumeLatestCalendarWizardPopupContext();
+    if (!contextId){
+      return { ok:false, error: bgI18n("talk_error_context_id_missing") };
+    }
+    L("talk popup context claimed", { contextId });
+    return { ok:true, contextId };
+  }
   if (msg.type === "talk:initDialog"){
     const contextId = readMessageContextId(msg);
     if (!contextId){

--- a/ui/talkDialog.html
+++ b/ui/talkDialog.html
@@ -112,6 +112,17 @@ textarea{
   background:var(--tb-surface);
   box-shadow:none;
 }
+.section-grid{
+  display:grid;
+  gap:var(--dialog-gap);
+  width:100%;
+}
+.section-grid-two{
+  grid-template-columns:repeat(2,minmax(0,1fr));
+}
+.section-grid .section{
+  min-width:0;
+}
 .section.delegate-section{
   flex:0 0 auto;
 }
@@ -554,6 +565,23 @@ textarea{
 .checkbox-row input[type="checkbox"]{
   accent-color:var(--dialog-accent);
 }
+.section-options{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:6px 14px;
+}
+.section-options .section-heading{
+  grid-column:1 / -1;
+  margin-bottom:0;
+}
+.section-options .checkbox-row{
+  margin:0;
+  min-width:0;
+}
+.section-options label:nth-of-type(even) .option-tooltip{
+  left:auto;
+  right:0;
+}
 .footer{
   border-top:1px solid var(--tb-border);
   padding:var(--dialog-gap) var(--dialog-pad-right) var(--dialog-gap) var(--dialog-pad-left);
@@ -660,48 +688,50 @@ textarea{
         <div id="policyWarningText" data-i18n="policy_warning_license_invalid">Your NC Connector license or seat is currently not valid. Local settings are used. Please contact your Nextcloud administrator.</div>
         <a id="policyWarningAdminLink" data-i18n="policy_warning_admin_link_label" target="_blank" rel="noopener noreferrer" href="https://github.com/nc-connector/NC_Connector_for_Thunderbird/blob/main/docs/ADMIN.md">Open admin setup guide</a>
       </div>
-      <div class="section">
-        <label for="titleInput" data-i18n="ui_create_title_label">Title</label>
-        <input id="titleInput" type="text">
-      </div>
-      <div class="section roomtype-section">
-        <label for="roomTypeButton" data-i18n="ui_create_roomtype_label">Room type</label>
-        <div class="roomtype-picker" id="roomTypePicker">
-          <button type="button" class="roomtype-button" id="roomTypeButton" aria-haspopup="listbox" aria-expanded="false">
-            <span class="roomtype-button-label" id="roomTypeButtonLabel" data-i18n="ui_create_mode_event">Event conversation</span>
-            <span class="roomtype-button-arrow" aria-hidden="true">▾</span>
-          </button>
-          <div class="roomtype-dropdown" id="roomTypeDropdown" role="listbox" hidden>
-            <button type="button" class="roomtype-option" data-value="event" data-selected="true" role="option">
-              <div class="roomtype-option-main">
-                <span class="roomtype-option-label" data-i18n="ui_create_mode_event">Event conversation</span>
-                <span class="roomtype-option-check" aria-hidden="true">✓</span>
-              </div>
-              <div class="roomtype-tooltip" role="tooltip">
-                <div class="roomtype-tooltip-title" data-i18n="talk_roomtype_event_title">📅 Event conversation</div>
-                <ul class="roomtype-tooltip-list">
-                  <li data-i18n="talk_roomtype_event_line1">Time-limited: for a specific appointment or occasion</li>
-                  <li data-i18n="talk_roomtype_event_line2">Spontaneous & lightweight: suitable for meetings, trainings or webinars</li>
-                  <li data-i18n="talk_roomtype_event_line3">Self-cleaning: removed automatically after some time</li>
-                </ul>
-              </div>
+      <div class="section-grid section-grid-two">
+        <div class="section">
+          <label for="titleInput" data-i18n="ui_create_title_label">Title</label>
+          <input id="titleInput" type="text">
+        </div>
+        <div class="section roomtype-section">
+          <label for="roomTypeButton" data-i18n="ui_create_roomtype_label">Room type</label>
+          <div class="roomtype-picker" id="roomTypePicker">
+            <button type="button" class="roomtype-button" id="roomTypeButton" aria-haspopup="listbox" aria-expanded="false">
+              <span class="roomtype-button-label" id="roomTypeButtonLabel" data-i18n="ui_create_mode_event">Event conversation</span>
+              <span class="roomtype-button-arrow" aria-hidden="true">▾</span>
             </button>
-            <button type="button" class="roomtype-option" data-value="normal" data-selected="false" role="option">
-              <div class="roomtype-option-main">
-                <span class="roomtype-option-label" data-i18n="ui_create_mode_standard">Group conversation</span>
-                <span class="roomtype-option-check" aria-hidden="true">✓</span>
-              </div>
-              <div class="roomtype-tooltip" role="tooltip">
-                <div class="roomtype-tooltip-title" data-i18n="talk_roomtype_group_title">🗨️ Group conversation</div>
-                <ul class="roomtype-tooltip-list">
-                  <li data-i18n="talk_roomtype_group_line1">Persistent: remains until it is actively deleted</li>
-                  <li data-i18n="talk_roomtype_group_line2">Everyday use: ideal for teams, departments, ongoing projects and recurring appointments</li>
-                  <li data-i18n="talk_roomtype_group_line3">With history: the entire chat can be reviewed at any time</li>
-                </ul>
-              </div>
-            </button>
+            <div class="roomtype-dropdown" id="roomTypeDropdown" role="listbox" hidden>
+              <button type="button" class="roomtype-option" data-value="event" data-selected="true" role="option">
+                <div class="roomtype-option-main">
+                  <span class="roomtype-option-label" data-i18n="ui_create_mode_event">Event conversation</span>
+                  <span class="roomtype-option-check" aria-hidden="true">✓</span>
+                </div>
+                <div class="roomtype-tooltip" role="tooltip">
+                  <div class="roomtype-tooltip-title" data-i18n="talk_roomtype_event_title">📅 Event conversation</div>
+                  <ul class="roomtype-tooltip-list">
+                    <li data-i18n="talk_roomtype_event_line1">Time-limited: for a specific appointment or occasion</li>
+                    <li data-i18n="talk_roomtype_event_line2">Spontaneous & lightweight: suitable for meetings, trainings or webinars</li>
+                    <li data-i18n="talk_roomtype_event_line3">Self-cleaning: removed automatically after some time</li>
+                  </ul>
+                </div>
+              </button>
+              <button type="button" class="roomtype-option" data-value="normal" data-selected="false" role="option">
+                <div class="roomtype-option-main">
+                  <span class="roomtype-option-label" data-i18n="ui_create_mode_standard">Group conversation</span>
+                  <span class="roomtype-option-check" aria-hidden="true">✓</span>
+                </div>
+                <div class="roomtype-tooltip" role="tooltip">
+                  <div class="roomtype-tooltip-title" data-i18n="talk_roomtype_group_title">🗨️ Group conversation</div>
+                  <ul class="roomtype-tooltip-list">
+                    <li data-i18n="talk_roomtype_group_line1">Persistent: remains until it is actively deleted</li>
+                    <li data-i18n="talk_roomtype_group_line2">Everyday use: ideal for teams, departments, ongoing projects and recurring appointments</li>
+                    <li data-i18n="talk_roomtype_group_line3">With history: the entire chat can be reviewed at any time</li>
+                  </ul>
+                </div>
+              </button>
+            </div>
+            <input type="hidden" id="roomTypeValue" value="event">
           </div>
-          <input type="hidden" id="roomTypeValue" value="event">
         </div>
       </div>
       <div class="section password-section">

--- a/ui/talkDialog.js
+++ b/ui/talkDialog.js
@@ -9,6 +9,7 @@
   const POPUP_CONTENT_WIDTH = 520;
   const MIN_CONTENT_HEIGHT = 0;
   const CONTENT_MARGIN = 0;
+  const POPUP_CONTEXT_RETRY_DELAYS_MS = [0, 40, 80, 160, 320, 640];
   let layoutObserver = null;
   let isPageUnloading = false;
   let disposeDebugFlagMirror = null;
@@ -77,6 +78,38 @@
 
   function logUiError(scope, reportedError){
     globalThis.NCLogContext.safeConsoleError(LOG_PREFIX, scope, reportedError);
+  }
+
+  function waitForPopupContextRetry(delayMs){
+    const delay = Math.max(0, Number(delayMs) || 0);
+    if (!delay){
+      return Promise.resolve();
+    }
+    return new Promise(resolve => window.setTimeout(resolve, delay));
+  }
+
+  async function claimNativePopupContext(){
+    if (state.contextId){
+      return true;
+    }
+    for (const delayMs of POPUP_CONTEXT_RETRY_DELAYS_MS){
+      await waitForPopupContextRetry(delayMs);
+      try{
+        const response = await browser.runtime.sendMessage({
+          type: "talk:claimPopupContext"
+        });
+        if (response?.ok && typeof response.contextId === "string" && response.contextId.trim()){
+          state.contextId = response.contextId.trim();
+          logDebug("popup context claimed", {
+            contextId: state.contextId
+          });
+          return true;
+        }
+      }catch(error){
+        logUiError("claim popup context failed", error);
+      }
+    }
+    return false;
   }
 
   /**
@@ -416,7 +449,7 @@
   async function bootstrapDialog(){
     await initDebugLogging();
     bindEvents();
-    if (!state.contextId){
+    if (!state.contextId && !(await claimNativePopupContext())){
       setMessage(t("talk_error_context_id_missing"), true);
       return;
     }


### PR DESCRIPTION
Use the native calendar item action popup for the Talk wizard to improve focus behavior in Thunderbird event editors, especially on Linux. The popup context is prepared before opening and claimed by the wizard at startup, while the layout was made more compact to fit the native popup surface without unnecessary scrolling.